### PR TITLE
Fix C*3 https://github.com/pingginp/cqlc/issues/7

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ The main modification we have are listed below
 ### Generator
 
 - generator now compiles, caused by breaking change of constant name in gocql
+
+The overall generator logic is
+
+- get table meta using gocql
+- render the template defined in `tmpl.go` using template helper methods defined in `template.go`
+  - `valueType` is returning empty value for `text`, just add a new mapping in `literalTypes` fixed this [#7](https://github.com/pingginp/cqlc/issues/7)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -144,7 +144,7 @@ func generateBinding(opts *Options, version string, w io.Writer) error {
 		return err
 	}
 
-	log.Printf("keyspace meta %v\n", md)
+	log.Printf("keyspace meta %v", md)
 
 	provenance := Provenance{
 		Keyspace:      opts.Keyspace,
@@ -167,6 +167,8 @@ func generateBinding(opts *Options, version string, w io.Writer) error {
 		return err
 	}
 
+	//ioutil.WriteFile("testdata/tmp.go", b.Bytes(), 0664)
+
 	log.Println("template rendered")
 
 	// FIXME: got error when formatting source https://github.com/pingginp/cqlc/issues/7
@@ -187,6 +189,8 @@ func generateBinding(opts *Options, version string, w io.Writer) error {
 }
 
 func importPaths(md *gocql.KeyspaceMetadata) (imports []string) {
+	log.Println("importPaths called")
+
 	// Ideally need to use a set
 	paths := make(map[string]bool)
 
@@ -203,15 +207,24 @@ func importPaths(md *gocql.KeyspaceMetadata) (imports []string) {
 			switch t.Type() {
 			case gocql.TypeList, gocql.TypeSet:
 				// TODO should probably not swallow this
-				ct, _ := t.(gocql.CollectionType)
+				ct, ok := t.(gocql.CollectionType)
+				if !ok {
+					panic("list set")
+				}
 				f(ct.Elem)
 			case gocql.TypeMap:
 				// TODO should probably not swallow this
-				ct, _ := t.(gocql.CollectionType)
+				ct, ok := t.(gocql.CollectionType)
+				if !ok {
+					panic("map")
+				}
 				f(ct.Key)
 				f(ct.Elem)
 			default:
-				nt, _ := t.(gocql.NativeType)
+				nt, ok := t.(gocql.NativeType)
+				if !ok {
+					panic("native")
+				}
 				f(nt)
 			}
 		}

--- a/generator/schema.go
+++ b/generator/schema.go
@@ -12,6 +12,7 @@ var (
 var literalTypes = map[gocql.Type]string{
 	gocql.TypeAscii:     "string",
 	gocql.TypeVarchar:   "string",
+	gocql.TypeText:      "string", // the only fix needed for support C*3 ...
 	gocql.TypeInt:       "int32",
 	gocql.TypeBigInt:    "int64",
 	gocql.TypeFloat:     "float32",

--- a/generator/template.go
+++ b/generator/template.go
@@ -132,19 +132,26 @@ func columnType(c gocql.ColumnMetadata, table *gocql.TableMetadata) string {
 	return baseType
 }
 
-func valueType(c gocql.ColumnMetadata) string {
+func valueType(c gocql.ColumnMetadata) (res string) {
+	//defer func() {
+	//	log.Printf("col %s %s %s", c.Name, c.Type, res)
+	//}()
 
 	t := c.Type
 
 	switch t.Type() {
 	case gocql.TypeList, gocql.TypeSet:
-		// TODO should probably not swallow this
-		ct, _ := t.(gocql.CollectionType)
+		ct, ok := t.(gocql.CollectionType)
+		if !ok {
+			panic("valueType list, set not collection")
+		}
 		literal := literalTypes[ct.Elem.Type()]
 		return fmt.Sprintf("[]%s", literal)
 	case gocql.TypeMap:
-		// TODO should probably not swallow this
-		ct, _ := t.(gocql.CollectionType)
+		ct, ok := t.(gocql.CollectionType)
+		if !ok {
+			panic("valueType map not collection")
+		}
 		key := literalTypes[ct.Key.Type()]
 		elem := literalTypes[ct.Elem.Type()]
 		return fmt.Sprintf("map[%s]%s", key, elem)


### PR DESCRIPTION
Fix #7 

- `gocql.TypeText` was not mapped to string, so generated file is invalid, could be in C*2 there is no Text in mapping ...